### PR TITLE
yaman: add pull policies

### DIFF
--- a/cmd/yaman/image/pull.go
+++ b/cmd/yaman/image/pull.go
@@ -27,7 +27,9 @@ func pull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	opts := registry.PullOpts{}
+	opts := registry.PullOpts{
+		Policy: registry.PullAlways,
+	}
 	if err := registry.Pull(img, opts); err != nil {
 		return err
 	}

--- a/internal/yaman/registry/pull.go
+++ b/internal/yaman/registry/pull.go
@@ -9,14 +9,41 @@ import (
 	"github.com/willdurand/containers/internal/yaman/image"
 )
 
+type PullPolicy string
+
 // PullOpts contains options for the pull operation.
-type PullOpts struct{}
+type PullOpts struct {
+	Policy PullPolicy
+}
+
+const (
+	// PullAlways means that we always pull the image.
+	PullAlways PullPolicy = "always"
+	// PullMissing means that we pull the image if it does not already exist.
+	PullMissing PullPolicy = "missing"
+	// PullNever means that we never pull the image.
+	PullNever PullPolicy = "never"
+)
 
 // Pull downloads and unpacks an image from a registry.
 func Pull(img *image.Image, opts PullOpts) error {
-	_, err := os.Stat(img.BaseDir)
+	if opts.Policy == PullNever {
+		return nil
+	}
+
+	st, err := os.Stat(img.BaseDir)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
+	}
+
+	if st != nil && st.IsDir() {
+		if opts.Policy == PullMissing {
+			return nil
+		}
+
+		if err := os.RemoveAll(img.BaseDir); err != nil {
+			return err
+		}
 	}
 
 	switch img.Hostname {


### PR DESCRIPTION
This is useful to control the behavior of the Pull operation. For instance, we probably always want to pull an image with 'image pull' but only when the image is missing when executing 'container run'.