### PR TITLE
yaman: use fuse-overlayfs when possible

### DIFF
--- a/cmd/yaman/README.md
+++ b/cmd/yaman/README.md
@@ -1,12 +1,12 @@
 # Yet Another (container) MANager
 
-Yaman is a daemon-less container manager inspired by [Docker][] and [Podman][].
+Yaman is a daemon-less container manager inspired by [Docker][] and [Podman][] that does not need `root`-like privileges.
 
 ## Commands
 
 **👋 Make sure to [follow these instructions](../../README.md#building-this-project) first.**
 
-⚠️ You must have "root" privileges to use `yaman` because the tool needs to mount the "rootfs" of a container as an Overlay FS. You can use `sudo yaman` as shown in the next sections.
+⚠️ You must have a recent version of [fuse-overlay][] installed. When `fuse-overlay` is not installed, Yaman will fallback to native OverlayFS but that usually requires elevated privileges (with `sudo` for example).
 
 ### `yaman container`
 
@@ -21,7 +21,7 @@ Alias: `yaman c`
 Let's run the image named [`docker.io/willdurand/hello-world`][hello-world]. This is a simple example inspired by Docker's [hello-world][hello-world-docker].
 
 ``` console
-$ sudo yaman c run docker.io/willdurand/hello-world
+$ yaman c run docker.io/willdurand/hello-world
 
 Hello from @willdurand!
 
@@ -39,7 +39,7 @@ To generate this message, Yaman took the following steps:
     to your terminal. Amazing, right?
 
 To try something more ambitious, you can run an Alpine container with:
- $ sudo yaman c run -it docker.io/library/alpine sh
+ $ yaman c run -it docker.io/library/alpine sh
 
 That's basically it because this is a learning project :D
 
@@ -51,25 +51,25 @@ For more examples and ideas, visit:
 Run a container in the background with `--detach` (short version: `-d`):
 
 ``` console
-$ sudo yaman c run -d docker.io/library/alpine:latest sleep 1000
+$ yaman c run -d docker.io/library/alpine:latest sleep 1000
 2be09afa2b3b47c2a9975017aa2913fc
 ```
 
 Change the container's hostname with `--hostname`:
 
 ``` console
-$ sudo yaman c run --hostname="hello" docker.io/library/alpine:latest -- hostname
+$ yaman c run --hostname="hello" docker.io/library/alpine:latest -- hostname
 hello
 ```
 
 Create an interactive container (that keeps `stdin` open) with `--interactive` (short version: `-i`):
 
 ``` console
-$ echo 'hello there' | sudo yaman c run --interactive docker.io/library/alpine -- cat
+$ echo 'hello there' | yaman c run --interactive docker.io/library/alpine -- cat
 hello there
 ^C
 
-$ sudo yaman c list
+$ yaman c list
 CONTAINER ID                       IMAGE                             COMMAND   STATUS      NAME
 103493075a744ec0b47a3a9a6aed473e   docker.io/library/alpine:latest   cat       running     elated_bell
 ```
@@ -77,7 +77,7 @@ CONTAINER ID                       IMAGE                             COMMAND   S
 Spawn an interactive shell with both `-i` and `--tty` (short version: `-t`):
 
 ``` console
-$ sudo yaman c run -it docker.io/library/alpine sh
+$ yaman c run -it docker.io/library/alpine sh
 / # id
 uid=0(root) gid=0(root) groups=0(root)
 / # hostname
@@ -89,7 +89,7 @@ uid=0(root) gid=0(root) groups=0(root)
 #### `yaman container inspect`
 
 ``` console
-$ sudo yaman c inspect 2be09afa2b3b47c2a9975017aa2913fc
+$ yaman c inspect 2be09afa2b3b47c2a9975017aa2913fc
 ```
 
 <details>
@@ -303,7 +303,7 @@ $ sudo yaman c inspect 2be09afa2b3b47c2a9975017aa2913fc
 #### `yaman container stop`
 
 ``` console
-$ sudo yaman c stop 2be09afa2b3b47c2a9975017aa2913fc
+$ yaman c stop 2be09afa2b3b47c2a9975017aa2913fc
 ```
 
 #### `yaman container list`
@@ -311,7 +311,7 @@ $ sudo yaman c stop 2be09afa2b3b47c2a9975017aa2913fc
 List all containers and not only those currently running:
 
 ``` console
-$ sudo yaman c list --all
+$ yaman c list --all
 CONTAINER ID                       IMAGE                             COMMAND    STATUS                          NAME
 1234e4a90ed042dc96b1a6f80417b75a   docker.io/library/alpine:latest   hostname   Exited (0) About a minute ago   great_hermann
 ```
@@ -319,16 +319,16 @@ CONTAINER ID                       IMAGE                             COMMAND    
 #### `yaman container delete`
 
 ``` console
-$ sudo yaman c delete 2be09afa2b3b47c2a9975017aa2913fc
+$ yaman c delete 2be09afa2b3b47c2a9975017aa2913fc
 ```
 
 #### `yaman container attach`
 
 ``` console
-$ sudo yaman c run -d --rm docker.io/library/alpine -- top -b
+$ yaman c run -d --rm docker.io/library/alpine -- top -b
 4bd06a2046e44e1d96c636c7ecae62d4
 
-$ sudo yaman c attach 4bd06a2046e44e1d96c636c7ecae62d4
+$ yaman c attach 4bd06a2046e44e1d96c636c7ecae62d4
 Mem: 719244K used, 280824K free, 12244K shrd, 28092K buff, 407436K cached
 CPU:   0% usr   0% sys   0% nic  95% idle   0% io   0% irq   4% sirq
 Load average: 0.17 0.07 0.07 2/177 5
@@ -352,10 +352,10 @@ Load average: 0.15 0.07 0.07 2/183 5
 We can also attach a container that was created with a terminal (PTY):
 
 ``` console
-$ sudo yaman c run -it -d --rm docker.io/library/alpine -- sh
+$ yaman c run -it -d --rm docker.io/library/alpine -- sh
 a932b1afa47341d183abf16d36aa33dd
 
-$ sudo yaman c attach a932b1afa47341d183abf16d36aa33dd
+$ yaman c attach a932b1afa47341d183abf16d36aa33dd
 / #
 ```
 
@@ -372,14 +372,14 @@ Alias: `yaman i`
 #### `yaman image pull`
 
 ``` console
-$ sudo yaman image pull docker.io/library/hello-world
+$ yaman image pull docker.io/library/hello-world
 downloaded docker.io/library/hello-world:latest
 ```
 
 #### `yaman image list`
 
 ``` console
-$ sudo yaman image list
+$ yaman image list
 NAME                  TAG         CREATED                PULLED           REGISTRY
 library/hello-world   latest      2021-09-23T23:47:57Z   12 minutes ago   docker.io
 library/redis         latest      2022-06-13T20:08:18Z   10 minutes ago   docker.io
@@ -392,7 +392,7 @@ Yaman uses the [yacs](../yacs/README.md) shim under the hood, which should be ab
 This is an example with `runc`:
 
 ``` console
-$ sudo yaman c run --rm -it --runtime=runc docker.io/library/alpine sh
+$ yaman c run --rm -it --runtime=runc docker.io/library/alpine sh
 / # hostname
 af5479f3265a49f78569b8b65c7d1412
 ```
@@ -400,7 +400,7 @@ af5479f3265a49f78569b8b65c7d1412
 In a different terminal, we can query `runc` manually and see the container above listed:
 
 ``` console
-$ sudo runc list
+$ runc list
 ID                                 PID         STATUS    BUNDLE                                                   CREATED                          OWNER
 af5479f3265a49f78569b8b65c7d1412   3394        running   /tmp/yaman/containers/af5479f3265a49f78569b8b65c7d1412   2022-06-17T20:06:38.326130089Z   root
 ```
@@ -408,7 +408,7 @@ af5479f3265a49f78569b8b65c7d1412   3394        running   /tmp/yaman/containers/a
 `runc` being the reference implementation and a production-ready tool, it has more features. For example, we can `exec` an existing container:
 
 ``` console
-$ sudo runc exec -t af5479f3265a49f78569b8b65c7d1412 sh
+$ runc exec -t af5479f3265a49f78569b8b65c7d1412 sh
 / # echo "hello" > /some-file
 / #
 ```
@@ -416,7 +416,7 @@ $ sudo runc exec -t af5479f3265a49f78569b8b65c7d1412 sh
 If we go back to the terminal where `yaman` is running, we should be able to see the newly created file and output its content:
 
 ``` console
-$ sudo yaman c run --rm -it --runtime=runc docker.io/library/alpine sh
+$ yaman c run --rm -it --runtime=runc docker.io/library/alpine sh
 / # hostname
 af5479f3265a49f78569b8b65c7d1412
 / # ls


### PR DESCRIPTION
Fixes #51

---

This PR effectively allows `yaman` to be used without `sudo`.